### PR TITLE
末尾の不要な"を削除

### DIFF
--- a/when_use.html
+++ b/when_use.html
@@ -31,7 +31,7 @@
         <h2>資料</h2>
         <h3><a href="https://github.com/Reactive-Extensions/RxJS/tree/master/doc/designguidelines#2-when-to-use-rxjs">RxJSデザインガイドライン</a></h3>
 
-        <h2>RxJSデザインガイドラインの"2. When to Use RxJS"の訳"</h2>
+        <h2>RxJSデザインガイドラインの"2. When to Use RxJS"の訳</h2>
         <h3>2.1 RxJS活用ケース: 非同期・イベントベースの処理を統合・編集するとき</h3>
         
         <p>複数のイベントや非同期処理を扱うコードは、処理の順番を扱うために状態マシンを定義する必要があり、その結果コードがすぐに複雑になってしまいます。<br />


### PR DESCRIPTION
`RxJSデザインガイドラインの"2. When to Use RxJS"の訳"`

末尾に不要と思われる`"`が残っていたため、それを削除しました。
